### PR TITLE
商品削除機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :move_to_index, only: [:edit, :update]
+  before_action :move_to_index, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.all.order("created_at DESC")
@@ -34,7 +34,10 @@ class ItemsController < ApplicationController
     end
   end
 
-
+  def destroy
+    @item.destroy
+    redirect_to root_path
+  end
 
   private
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
       <% if current_user.id == @item.user_id %>
     <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
# What
商品削除機能作成
# Why
商品削除機能を実装するため

出品者のみ表示される「削除ボタン」をおすと商品が削除されトップページに遷移
https://i.gyazo.com/bd3204612d76beaae1ffb30a95836414.mp4

こちらを実装した後、出品者以外が商品を削除出来なくするためitemsコントローラーのbefore_action :move_to_index, onlyにdestroyを追加しましたが、そもそも削除ページがないのでこちらが必要か分からなかったのでご意見いただけると助かります。
それではご確認よろしくお願いします。